### PR TITLE
update readme about installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,21 @@ Arweave Deploy that saves you data costs.
 arkb runs using NodeJS and NPM. You must have both installed on your machine for it to work.
 
 Install arkb:
+
+```
+yarn global add arkb # recommended
+```
+
+or
+
 ```
 npm install -g arkb
 ```
 
+> **Note:** The installation of arkb needs that node >=15.11.0 or you will get an error even you successfully have the arkb installed.  For managing multiple active nodejs, we recommend you have [nvm](https://github.com/nvm-sh/nvm) installed on your computer, then you can switch different node in a simple command. 
+
 And run:
+
 ```
 arkb help
 ```


### PR DESCRIPTION
I met a error when installing arkb with npm and node 14, then i try to fix the installation, then i use yarn for installation, then it explict tell me that the node version needs to greater than 15.11.0, which the `readme` don't mentioned, so i add some information about installation.