### PR TITLE
fix: fix cli.default[color] break status command

### DIFF
--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -62,8 +62,7 @@ Transaction URL: ${parseColor(colors, `${arweaveUri}/${txid}`, 'cyan')}
 Block URL: ${parseColor(colors, `${arweaveUri}/block/hash/${res.blockHash}`, 'cyan')}
 
 Transaction explorer URL: ${parseColor(colors, `https://viewblock.io/arweave/tx/${txid}`, 'cyan')}
-Block explorer URL: ${parseColor(colors, `https://viewblock.io/arweave/block/${res.blockHeight}`)}`,
-          'cyan',
+Block explorer URL: ${parseColor(colors, `https://viewblock.io/arweave/block/${res.blockHeight}`, 'cyan')}`,
         );
       }
     } catch (e) {


### PR DESCRIPTION
@cedriking This fixes the following bug on the `status` command:

```batch
PS C:\Users\Fuad\Downloads\amazon-letters> arkb status FqcTfQHqgXhUG1CWoarkE2hN-rHRpbiCXxT_OGOSlJ8
🚀 ~ file: status.ts ~ line 20 ~ .then ~ res {
  blockHeight: 859094,
  blockHash: 'gwYko5Rc-klQ74i2H7F4qnKIvqlDg9RZ0oP_CaAeijzc9qk7NdIgRD3_6b_VqgXQ',
  confirmations: 9,
  status: 200
}
Trasaction ID: FqcTfQHqgXhUG1CWoarkE2hN-rHRpbiCXxT_OGOSlJ8

Status: 200 - Accepted
Unable to reach https://arweave.net - cli_color_1.default[color] is not a function
```