### PR TITLE
:memo: chore: add index option to help preview

### DIFF
--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -1,0 +1,9 @@
+import OptionInterface from '../faces/option';
+
+const option: OptionInterface = {
+  name: 'index',
+  alias: 'i',
+  description: 'Set path manifest index for a directory upload',
+};
+
+export default option;


### PR DESCRIPTION
![Screenshot from 2022-05-31 17-32-03](https://user-images.githubusercontent.com/65264054/171226976-66f8f906-85d6-4a24-9133-b8b2378e843a.png)

The --index option is missing from the help preview.. It is only present in the examples section of the help preview currently.