### PR TITLE
:bug: fix: fix file bundles upload

### DIFF
--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -17,6 +17,7 @@ import { JWKInterface } from 'blockweave/dist/faces/lib/wallet';
 import Transaction from 'blockweave/dist/lib/transaction';
 import { createTransactionAsync, uploadTransactionAsync } from 'arweave-stream-tx';
 import Arweave from 'arweave';
+import ArweaveTransaction from 'arweave/node/lib/transaction';
 import Cache from '../utils/cache';
 
 export default class Deploy {
@@ -225,11 +226,9 @@ export default class Deploy {
     if (useBundler || this.localBundle) {
       this.bundle = await this.bundler.bundleAndSign(this.txs.map((t) => t.tx) as FileDataItem[]);
 
-      // @ts-ignore
-      this.bundledTx = await this.bundle.toTransaction(this.arweave, this.wallet);
+      this.bundledTx = (await this.bundle.toTransaction({}, this.arweave, this.wallet)) as any;
 
-      // @ts-ignore
-      await this.arweave.transactions.sign(this.bundledTx, this.wallet);
+      await this.arweave.transactions.sign(this.bundledTx as unknown as ArweaveTransaction, this.wallet);
     }
 
     return this.txs;


### PR DESCRIPTION
# Overview

fixes the below error when using bundler upload.

```bash
TypeError: Cannot read properties of undefined (reading 'getTransactionAnchor')
    at /home/fuad/Documents/organizations/textury/arkb/node_modules/arweave-stream-tx/dist/create-transaction-async.js:20:111
    at processTicksAndRejections (node:internal/process/task_queues:96:5)

```